### PR TITLE
change detail.error type to string

### DIFF
--- a/src/vaadin-upload.html
+++ b/src/vaadin-upload.html
@@ -809,7 +809,7 @@ This program is available under Apache License Version 2.0, available at https:/
         * @event file-reject
         * @param {Object} detail
         * @param {Object} detail.file the file added
-        * @param {Object} detail.error the cause
+        * @param {String} detail.error the cause
         */
 
         /**


### PR DESCRIPTION
This error causes the generated Flow component to have the wrong JSON type which causes an exception in that prevents Flow from dispatching the event correctly on the server-side.

See the generated Flow type here: https://github.com/vaadin/vaadin-upload-flow/blob/5ad2b85da574a3dcaa1198f259d10dc439dc57c0/vaadin-upload-flow/src/main/java/com/vaadin/flow/component/upload/GeneratedVaadinUpload.java#L809